### PR TITLE
1주차 2일차 박현우: 스택/큐 문제풀이

### DIFF
--- a/1주차-Stack-Queue/박현우/기능개발.js
+++ b/1주차-Stack-Queue/박현우/기능개발.js
@@ -1,0 +1,40 @@
+function solution(progresses, speeds) {
+  let bucket = [];
+  const answer = [];
+
+  let i = 0;
+
+  while (progresses.length) {
+    progresses[i] += speeds[i];
+    i++;
+    // 하루치 일감 진도 나가기, 인덱스 + 1
+
+    if (progresses[0] < 100) {
+      if (bucket.length) {
+        answer.push(bucket.length);
+        bucket = [];
+      }
+
+      if (i >= progresses.length) {
+        i = 0;
+      }
+    } else {
+      bucket.push("");
+      progresses.shift();
+      speeds.shift();
+      i = 0;
+    }
+  }
+
+  answer.push(bucket.length);
+  return answer;
+}
+
+// 조건1 첫번째 일감이 끝나지 않았을 때 (progresses[0] 이 100보다 작을때)
+// 조건1을 만족하고 i가 progresses의 length 보다 클 경우 i 초기화 해서 진도를 멈추지 않게 처리
+
+// 조건1을 만족하지 못할 때 (progresses[0] 이 100보다 크거나 같을 때)
+//bucket에 임의의 값을 넣고 progresses, speeds에서 0번 값을 빼 새로운 0번 값이 조건1에서 검사, 각 배열의 인덱스가 바뀌기 때문에 i 초기화
+
+// 조건1을 만족하고 bucket에 요소가 존재할 때(0번 값이 끝나지 않은 상태일 때 더 이상 완료 될 작업이 없음) bucket의 길이(완료된 일감 개수)를 answer 에 push 후 bucket를 비운다.
+// progresses에 요소가 남아있지 않을 때 까지 반복


### PR DESCRIPTION
# 문제1

## 문제 링크
URL: https://school.programmers.co.kr/learn/courses/30/lessons/42586

## 문제 설명
progresses에 담긴 요소(현재 진도)들은 각각 하루에 같은 인덱스의 speeds 에 담긴 요소(하루에 나갈 수 있는 진도)만큼 개발 가능
여러 기능이 순차적으로 배포되어야 하기 때문에 뒤에있는 기능이 완료(진도가 100이상이 될 때)되더라도 앞의 기능이 배포되지 않으면 배포 불가능
배포는 하루에 한번 하루의 끝에 이루어짐
각 배포마다 몇개의 기능이 완료되어 배포 되는지 구해서 반환

제한사항: 
1. 작업의 개수(progresses, speeds배열의 길이)는 100개 이하
1. 작업 진도는 100 미만의 자연수
1. 작업 속도는 100 이하의 자연수

## 리뷰 요구 사항

- 반복이 중첩되는 상황을 피하려다 보니 코드가 길어지고 가독성이 떨어진다고 느꼈습니다. 개선 방안이 있다면 추천 부탁드립니다.
- bucket 이라는 배열을 재할당 하는 방법 말고 좋은 방법이 있다면 추천 부탁드립니다.